### PR TITLE
Create config var for username while deploying on Heroku

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ var options = {
 		reconnect: true
 	},
 	identity: {
-		username: "susiaibot",
+		username: process.env.USERNAME,
 		password: process.env.OAUTH_TOKEN
 	},
 	channels: [userChannel]
@@ -47,11 +47,10 @@ client.on('chat', function(channel, userstate, message, self){
 });
 
 client.on('connected', function(address, port){
-	//console.log(`Address: ${address}, Port: ${port}`);
 	client.action(userChannel, "Welcome, I'm SUSI.");
 });
 
 const port = process.env.PORT || 3000;
 app.listen(port, () => {
-   console.log(`listening on ${port}`);
+   console.log(`Listening on ${port}`);
 });


### PR DESCRIPTION
Fixes #10 

Changes: Added config var for username of bot account which is to be entered while deploying on Heroku.

