### PR TITLE
Fix License link

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,4 @@ For now, the default branch is master.
 
 ## License
 
-This project is licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 2.1. Please find more info in our [license document](LICENSE.md).
+This project is licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 2.1. Please find more info in our [license document](LICENSE).


### PR DESCRIPTION
Fixes #17 

Changes: Fixed the license link. Changed it from `LICENSE.md` to `LICENSE`.
